### PR TITLE
Update gem and README

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
     aws-eventstream (1.0.3)
     aws-partitions (1.194.0)
     aws-sdk-budgets (1.25.0)
@@ -18,31 +13,39 @@ GEM
       jmespath (~> 1.0)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-    concurrent-ruby (1.1.5)
-    faraday (0.15.4)
+    faraday (1.5.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
-    gli (2.18.1)
-    hashie (3.6.0)
-    i18n (1.6.0)
-      concurrent-ruby (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
+    faraday-patron (1.0.0)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    gli (2.20.1)
+    hashie (4.1.0)
     jmespath (1.4.0)
-    minitest (5.11.3)
     multipart-post (2.1.1)
-    slack-ruby-client (0.14.4)
-      activesupport
-      faraday (>= 0.9)
+    ruby2_keywords (0.0.4)
+    slack-ruby-client (0.17.0)
+      faraday (>= 1.0)
       faraday_middleware
       gli
       hashie
       websocket-driver
-    thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
-    websocket-driver (0.7.1)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
 
 PLATFORMS
   ruby
@@ -52,4 +55,4 @@ DEPENDENCIES
   slack-ruby-client
 
 BUNDLED WITH
-   1.17.3
+   2.1.2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,33 @@ and rewritten in Ruby with added emoji.
 ## Packaging for Lambda
 
 ```
-bundle install --path vendor/bundle
+rm -rf vendor/
+bundle config set path 'vendor/bundle'
+bundle install
 zip -r lambda_function.zip lambda_function.rb vendor/
 ```
+
+## Updating this function
+
+You will need to manually upload the zip file via the AWS management console. 
+Do not commit the zip file in this repo. 
+
+If we're upgrading the Ruby version, you can run: 
+
+```
+aws lambda update-function-configuration --function-name aws-budget-slack --runtime ruby2.7
+```
+
+This can't be done via the UI. 
+
+## Authenticating with the Slack API
+
+We use the `aws_accountant` user to post budget updates. We post using an API 
+token which can be generated here:
+
+https://futurelearn.slack.com/services/BLYSSAL78
+
+You will need to update `SLACK_API_TOKEN` in the lambda config settings. This can 
+be done via the UI. 
+
+You might have to re-add the slack user to the channel where you want to post. 


### PR DESCRIPTION
We've now upgraded this lambda function from Ruby 2.5 to Ruby 2.7. 

When running the code we get a warning from an outdated version of the `faraday` gem:
```
warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

The `faraday` gem is a dependency of `slack-ruby-client` so we're upgrading it to the latest version.

While we're here, we're also enriching the README with more info about how to deploy and update 
this lambda. 

[Trello](https://trello.com/c/iBNJIru2/2545-update-lambda-runtimes-for-ruby-and-python)